### PR TITLE
Use `statistics.mean` instead of custom `avg` function?

### DIFF
--- a/gif_for_cli/generate/__init__.py
+++ b/gif_for_cli/generate/__init__.py
@@ -13,26 +13,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from collections import OrderedDict
 import json
 import math
-import os
 import re
 import subprocess
+from collections import OrderedDict
 
 from PIL import Image
 
-from ..constants import ANSI_RESET, NOCOLOR_CHARS
-from ..utils import get_sorted_filenames, pool_abstraction
-
 from .utils import (
-    avg,
     get_gray,
     get_256_cell,
     get_256fgbg_cell,
     get_truecolor_cell,
     get_avg_for_em,
 )
+from ..constants import ANSI_RESET, NOCOLOR_CHARS
+from ..utils import get_sorted_filenames, pool_abstraction
 
 
 def _save_config(num_frames, seconds, **options):

--- a/gif_for_cli/generate/utils.py
+++ b/gif_for_cli/generate/utils.py
@@ -13,27 +13,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from json.decoder import JSONDecodeError
 import math
 import os
+from json.decoder import JSONDecodeError
+from statistics import mean
 
 import requests
 from x256 import x256
 
+from .x256fgbg_utils import top_2_colors
 from ..constants import X256FGBG_CHARS, STORED_CELL_CHAR
 from ..utils import memoize
-
-from .x256fgbg_utils import top_2_colors
-
-
-def avg(it):
-    l = len(it)
-    return sum(it) / float(l)
 
 
 @memoize
 def get_gray(*rgb):
-    return avg(rgb)
+    return mean(rgb)
 
 
 @memoize
@@ -73,7 +68,7 @@ def get_avg_for_em(px, x, y, cell_height, cell_width):
         for sy in range(y, y + cell_height)
         for sx in range(x, x + cell_width)
     ]
-    return [round(n) for n in map(avg, zip(*pixels))]
+    return [round(n) for n in map(mean, zip(*pixels))]
 
 
 def process_input_source(input_source, api_key):

--- a/tests/generate/test_utils.py
+++ b/tests/generate/test_utils.py
@@ -20,42 +20,15 @@ from unittest.mock import patch, Mock
 from PIL import Image
 
 from gif_for_cli.generate.utils import (
-    avg,
     get_gray,
     get_256_cell,
     get_truecolor_cell,
     get_avg_for_em,
     process_input_source,
 )
-
 from ..fixtures import empty_gif_response, gif_response
 
-
 api_key = 'TQ7VXFHXBJQ5'
-
-
-class TestAvg(unittest.TestCase):
-    def test_empty_input_raises_error(self):
-        with self.assertRaises(ZeroDivisionError):
-            avg([])
-
-    def test_single_int_in_float_out(self):
-        out = avg([1])
-
-        self.assertEqual(out, 1.0)
-        self.assertEqual(type(out), float)
-
-    def test_ints_in_float_out(self):
-        out = avg([1, 2])
-
-        self.assertEqual(out, 1.5)
-        self.assertEqual(type(out), float)
-
-    def test_floats_in_float_out(self):
-        out = avg([1.1, 2.2])
-
-        self.assertAlmostEqual(out, 1.65)
-        self.assertEqual(type(out), float)
 
 
 class TestGetGray(unittest.TestCase):

--- a/tests/generate/test_utils.py
+++ b/tests/generate/test_utils.py
@@ -72,8 +72,6 @@ class TestGetAvgForEm(unittest.TestCase):
     def test_default_black_block(self):
         out = get_avg_for_em(self.px, 0, 0, 2, 2)
 
-        out = get_avg_for_em(self.px, 0, 0, 2, 2)
-
         self.assertColor(out, self.black)
 
         out = get_avg_for_em(self.px, 2, 0, 2, 2)


### PR DESCRIPTION
https://github.com/google/gif-for-cli/blob/288b7b3ae88661ca805ac8c6b574a8448bcf37d9/gif_for_cli/generate/utils.py#L29-L31

Looking at the `avg` function, I was curious about potentially using [`statistics.mean`](https://docs.python.org/3/library/statistics.html#statistics.mean) instead. The functionality between the two seemed the same except for `avg` always returning a float VS `statistics.mean` sometimes returning an integer (where applicable).

```python
>>> avg([1])
1.0
>>> mean([1])
1
>>> avg([1, 2, 5])
2.6666666666666665
>>> mean([1, 2, 5])
2.6666666666666665
```

The main issue was that `statistics.mean` requires `Python 3.4+` but the installation instructions in the README only mentioned `Python 3`:

> [Requires Python 3 (with setuptools and pip) ...](https://github.com/google/gif-for-cli#installation)

Looking at the docs for the dependency [`Pillow`](https://pillow.readthedocs.io/en/5.1.x/) seemed to indicate that `3.4` would be the minimum supported version for `gif-for-cli`:

> [Pillow >= 5.0.0 supports Python versions 2.7, 3.4, 3.5, 3.6](https://pillow.readthedocs.io/en/5.1.x/installation.html#notes)

As long it's acceptable to have an integer returned in some cases instead of always returning a float, removing the `avg` function allows some code and tests to be removed.

---
Other changes:
* Optimize imports [(using PyCharm)](https://www.jetbrains.com/help/pycharm/creating-and-optimizing-imports.html)
* Remove unnecessary duplicate line in tests
