### PR TITLE
create docker image for google/gif-for-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.6-alpine
+MAINTAINER pierrefenoll@gmail.com
+RUN set -x \
+ && apk update && apk upgrade \
+ && apk add ffmpeg zlib-dev libjpeg-turbo-dev \
+            gcc musl-dev \
+ && export PATH="$PATH:/root/.local/bin" \
+ && pip3 install --user gif-for-cli
+ENTRYPOINT ["/root/.local/bin/gif-for-cli"]


### PR DESCRIPTION
Note: you can try it out with `docker run --rm -it fenollp/gif-for-cli/tags`