### PR TITLE
Option to return path to generated file with `--no-display` option

### DIFF
--- a/gif_for_cli/execute.py
+++ b/gif_for_cli/execute.py
@@ -85,6 +85,8 @@ def execute(environ, argv, stdout):
             cpu_pool_size=args.cpu_pool_size,
             output_dirnames=output_dirnames,
         )
+    elif args.no_display and args.show_path:
+        print(output_dirnames[args.display_mode])
     elif not args.no_display:
         display(
             display_dirname=output_dirnames[args.display_mode],

--- a/gif_for_cli/utils.py
+++ b/gif_for_cli/utils.py
@@ -156,6 +156,13 @@ def get_parser(environ):
         help='Skip displaying ASCII in terminal, useful for pre-caching output.',
     )
 
+    parser.add_argument(
+        '--show_path',
+        dest='show_path',
+        action='store_true',
+        help='Print path to generated files, for use with --no_display mode.',
+    )
+
     # export related options, doens't affect generated output.
     parser.add_argument(
         '--export',

--- a/gif_for_cli/utils.py
+++ b/gif_for_cli/utils.py
@@ -61,7 +61,7 @@ def get_parser(environ):
 
     parser = argparse.ArgumentParser(
         prog='gif_for_cli',
-        description="""Convert .gif/.mp4 to animated ASCII art with or wihtout ANSI colors
+        description="""Convert .gif/.mp4 to animated ASCII art with or without ANSI colors
     and view it in your terminal. Supports querying Tenor GIF API.
     """,
         formatter_class=argparse.RawTextHelpFormatter,
@@ -155,9 +155,8 @@ def get_parser(environ):
         action='store_true',
         help='Skip displaying ASCII in terminal, useful for pre-caching output.',
     )
-
     parser.add_argument(
-        '--show_path',
+        '--show-path',
         dest='show_path',
         action='store_true',
         help='Print path to generated files, for use with --no_display mode.',


### PR DESCRIPTION
**Summary of changes**

- Fix small typo in help text
- Add `--show-path` option for use with `--no-display`

When pre-caching output, it is helpful to know the path to the cache for when the time comes to display the file.  Adding this as an extra option so that there is no change to existing functionality.
