### PR TITLE
Add missing "rows" option in _save_config

### DIFF
--- a/gif_for_cli/generate/__init__.py
+++ b/gif_for_cli/generate/__init__.py
@@ -39,6 +39,7 @@ def _save_config(num_frames, seconds, **options):
         for key in [
             'input_source',
             'input_source_file',
+            'rows',
             'cols',
             'cell_width',
             'cell_height',


### PR DESCRIPTION
Currently, `_save_config` is not including `rows` option in its iteration. As a result, `scale_height` becomes 0, which in turn causes issue [Can't use gif-for-cli (Float division by zero on execute.py)](https://github.com/google/gif-for-cli/issues/33). This patch includes `rows` option to fix this issue.