### PR TITLE
Add fallback regex method to _run_ffmpeg

### DIFF
--- a/gif_for_cli/generate/__init__.py
+++ b/gif_for_cli/generate/__init__.py
@@ -72,8 +72,13 @@ def _run_ffmpeg(input_source_file, output_dirnames, cols, rows, cell_width,
     err = err.decode('utf8')
 
     num_frames = int(re.search(r'frame=\s*(\d+)', err).group(1))
+    if (num_frames == 0):
+        num_frames = int(re.findall(r'frame=\s*(\d+)', err)[1])
     hours, minutes, seconds = re.search(r'time=(\d{2}):(\d{2}):(\d{2}.\d{2})', err).groups()
     seconds = float(seconds) + (int(minutes) * 60) + (int(hours) * 3600)
+    if (seconds == 0):
+        hours, minutes, seconds, = re.findall(r'time=(\d{2}):(\d{2}):(\d{2}.\d{2})', err)[1]
+        seconds = float(seconds) + (int(minutes) * 60) + (int(hours) * 3600)
     return num_frames, seconds
 
 

--- a/gif_for_cli/generate/__init__.py
+++ b/gif_for_cli/generate/__init__.py
@@ -39,6 +39,7 @@ def _save_config(num_frames, seconds, **options):
         for key in [
             'input_source',
             'input_source_file',
+            'rows',
             'cols',
             'cell_width',
             'cell_height',


### PR DESCRIPTION
Following [Add missing "rows" option in _save_config](https://github.com/google/gif-for-cli/pull/34), it is also possible `re.search` fails to match any groups in `err`. As a result, `num_frames` and `seconds` will be 0, which will also cause issue [Can't use gif-for-cli (Float division by zero on execute.py)](https://github.com/google/gif-for-cli/issues/33). Since this issue may be system-dependent (Arch Linux), I am making a separate PR for this fix. 